### PR TITLE
Bugfix: Added necessary package version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ plotly==2.0.13
 plyfile==0.5
 prettytable==0.7.2
 pyqtgraph==0.10.0
+python-dateutil==2.1
 scikit_learn==0.19.0
 scipy==1.0.0rc1
 seaborn==0.8.1


### PR DESCRIPTION
Other package installations invoke an installation of
the python package python-dateutil that has another version
than 2.1 which is required by nupic. Adding this package with
version fixed the issue