### PR TITLE
Tests & Bayesian-TM fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ pip-log.txt
 nosetests.xml
 htmlcov
 junit-test-results.xml
+./tests/bayesian/plots
 
 # Translations
 *.mo

--- a/htmresearch/algorithms/apical_tiebreak_bayesian_temporal_memory.py
+++ b/htmresearch/algorithms/apical_tiebreak_bayesian_temporal_memory.py
@@ -133,19 +133,19 @@ class ApicalTiebreakBayesianTemporalMemory(object):
     self.basalBias = np.zeros((self.numBasalSegments, self.columnCount*self.cellsPerColumn))
     self.apicalBias = np.zeros((self.numApicalSegments, self.columnCount*self.cellsPerColumn))
 
-    # Initialize moving averages with 1/(M_i*M_j), 1/(M_i) or 1/(M_j)
+    # Initialize moving averages uniformly with 1/(M_i*M_j), 1/(M_i) or 1/(M_j)
     self.basalMovingAverages = np.full(
-      (self.numBasalSegments, self.columnCount*self.cellsPerColumn, self.basalInputSize),
-      1.0/(self.numberOfCells()*self.basalInputSize)
+      (self.numBasalSegments, self.numberOfCells(), self.basalInputSize),
+      0.0
     )
     self.apicalMovingAverages = np.full(
-      (self.numApicalSegments, self.columnCount*self.cellsPerColumn, self.apicalInputSize),
-      1.0/(self.numberOfCells()*self.apicalInputSize)
+      (self.numApicalSegments, self.numberOfCells(), self.apicalInputSize),
+      0.0
     )
-    self.basalMovingAveragesBias = np.full((self.numBasalSegments, self.numberOfCells()), 1.0)
-    self.apicalMovingAveragesBias = np.full((self.numApicalSegments, self.numberOfCells()), 1.0)
-    self.basalMovingAverageInput = np.full(self.basalInputSize, 1.0)
-    self.apicalMovingAverageInput = np.full(self.apicalInputSize, 1.0)
+    self.basalMovingAveragesBias = np.full((self.numBasalSegments, self.numberOfCells()), 0.0)
+    self.apicalMovingAveragesBias = np.full((self.numApicalSegments, self.numberOfCells()), 0.0)
+    self.basalMovingAverageInput = np.full(self.basalInputSize, 0.0)
+    self.apicalMovingAverageInput = np.full(self.apicalInputSize, 0.0)
 
     # Set to zero to use randomly initialized first weight value
     self.basalSegmentCount = np.zeros((self.columnCount, self.cellsPerColumn))
@@ -358,8 +358,7 @@ class ApicalTiebreakBayesianTemporalMemory(object):
     numSegments = self.numApicalSegments if isApical else self.numBasalSegments
 
     if numSegments + 1 < self.maxSegmentsPerCell:
-      # TODO Check whether random or zeros is better
-      weight_matrix = np.append(weight_matrix, np.random.random((1, self.numberOfCells(), input_size)), axis=0)
+      weight_matrix = np.append(weight_matrix, np.zeros((1, self.numberOfCells(), input_size)), axis=0)
       average_matrix = np.append(average_matrix, np.zeros((1, self.numberOfCells(), input_size)), axis=0)
       bias_matrix = np.append(bias_matrix, np.zeros((1, self.numberOfCells())), axis=0)
       bias_average = np.append(bias_average, np.zeros((1, self.numberOfCells())), axis=0)
@@ -450,8 +449,23 @@ class ApicalTiebreakBayesianTemporalMemory(object):
       learningRate = self.learningRate
 
     numSegments = self.numApicalSegments if isApical else self.numBasalSegments
+
+    # Updating moving average input activity
+    noisy_input_vector = (1 - self.noise) * inputValues
+    # Consider only active segments
+    noisy_input_vector[noisy_input_vector > 0] += self.noise
+    movingAverageInput += learningRate * (
+            noisy_input_vector - movingAverageInput
+    )
+
+    # First update input values (includes learning rate)
+    # Then use the probabilities of activity for movingAverage calculation
+    # Instead of using 1 -> would lead to weight explosion, because we calculate weights based on MovingAverageInput
+    inputProbabilities = inputValues
+    inputProbabilities[inputValues.nonzero()] = movingAverageInput[inputValues.nonzero()]
+
     # Updating moving average weights to input
-    noisy_connection_matrix = np.outer((1 - self.noise**2) * segments, inputValues)
+    noisy_connection_matrix = np.outer((1 - self.noise**2) * segments, inputProbabilities)
     # Consider only active segments
     noisy_connection_matrix[noisy_connection_matrix > 0] += self.noise**2
     noisy_connection_matrix = noisy_connection_matrix.reshape(numSegments, self.numberOfCells(), inputSize)
@@ -466,13 +480,7 @@ class ApicalTiebreakBayesianTemporalMemory(object):
     movingAverageBias += learningRate * (
             noisy_activation_vector - movingAverageBias
     )
-    # Updating moving average input activity
-    noisy_input_vector = (1 - self.noise) * inputValues
-    # Consider only active segments
-    noisy_input_vector[noisy_input_vector > 0] += self.noise
-    movingAverageInput += learningRate * (
-            noisy_input_vector - movingAverageInput
-    )
+
     return movingAverage, movingAverageBias, movingAverageInput
 
   @staticmethod
@@ -514,6 +522,12 @@ class ApicalTiebreakBayesianTemporalMemory(object):
     ).reshape(movingAverages.shape)
     # set division by zero to zero since this represents unused segments
     weights[np.isnan(weights)] = 0
+
+    # Quote Sandberg: "A further minor complication relates to units that have never participated in any shown pattern.
+    # Such units will have a disruptive effect on the network due to extreme valued connections and biases. [..]
+    # By explicitly setting their connections w_ij = 1 their influence can be removed.
+    # ==> Against weight explosion
+    weights[weights > 1.0] = 1.0
 
     # Unused segments are set to -inf. That is desired since we take the exp function for the activation
     # exp(-inf) = 0 what is the desired outcome

--- a/tests/bayesian/bayesian_convergence_activity_plot.py
+++ b/tests/bayesian/bayesian_convergence_activity_plot.py
@@ -255,7 +255,7 @@ def runExperiment():
   numFeatures = 3 # new: 3 # original: 3
   numPoints = 5 # new: 5 # original: 10
   numLocations = 5 # new: 5 # original: 10
-  numObjects = 2 # new: 2 # original: 10
+  numObjects = 3 # new: 2 # original: 10
   numRptsPerSensation = 2
 
   objectMachine = createObjectMachine(
@@ -283,15 +283,16 @@ def runExperiment():
   # params
   maxNumSegments = 2
   L2Overrides = {
-    "learningRate": 0.1, 
-    "noise": 0.01,
+    "learningRate": 0.1,
+    "noise": 1e-6,
     "cellCount": 256, # new: 256 # original: 4096
     "inputWidth": 8192, # new: 8192 # original: 16384 (?)
+    "activationThreshold": 0.01
   }
 
   L4Overrides = {
     "learningRate": 0.1,
-    "noise": 0.01,
+    "noise": 1e-6,
     "cellsPerColumn": 4, # new: 4 # original 32
     "columnCount": 2048, # new: 2048 # original: 2048
     "minThreshold": 0.35,

--- a/tests/bayesian/test_baysian_cp_full.py
+++ b/tests/bayesian/test_baysian_cp_full.py
@@ -13,7 +13,7 @@ class BayesianCPTest(unittest.TestCase):
         maxNumSegments = 2
         L2Overrides = {
             "learningRate": 0.1,
-            "noise": 0.0001,
+            "noise": 1e-8,
             "cellCount": 256,  # new: 256 # original: 4096
             "inputWidth": 8192,  # new: 8192 # original: 16384 (?)
             "sdrSize": 5,
@@ -22,7 +22,7 @@ class BayesianCPTest(unittest.TestCase):
 
         L4Overrides = {
             "learningRate": 0.1,
-            "noise": 0.01,
+            "noise": 1e-8,
             "cellsPerColumn": 4,  # new: 4 # original 32
             "columnCount": 2048,  # new: 2048 # original: 2048
             "minThreshold": 0.35,

--- a/tests/bayesian/test_baysian_cp_full.py
+++ b/tests/bayesian/test_baysian_cp_full.py
@@ -1,0 +1,231 @@
+import unittest
+import numpy as np
+import pprint as pp
+
+from htmresearch.frameworks.layers.l2_l4_inference import L4L2Experiment
+from htmresearch.frameworks.layers.object_machine_factory import (
+  createObjectMachine
+)
+
+class BayesianCPTest(unittest.TestCase):
+    def setUp(self):
+        # params
+        maxNumSegments = 2
+        L2Overrides = {
+            "learningRate": 0.1,
+            "noise": 0.0001,
+            "cellCount": 256,  # new: 256 # original: 4096
+            "inputWidth": 8192,  # new: 8192 # original: 16384 (?)
+            "sdrSize": 5,
+            "activationThreshold": 0.01,
+        }
+
+        L4Overrides = {
+            "learningRate": 0.1,
+            "noise": 0.01,
+            "cellsPerColumn": 4,  # new: 4 # original 32
+            "columnCount": 2048,  # new: 2048 # original: 2048
+            "minThreshold": 0.35,
+        }
+
+        self.exp1 = L4L2Experiment(
+            'single_column',
+            implementation='BayesianApicalTiebreak',
+            L2RegionType="py.BayesianColumnPoolerRegion",
+            L4RegionType="py.BayesianApicalTMPairRegion",
+            L2Overrides=L2Overrides,
+            L4Overrides=L4Overrides,
+            numCorticalColumns=1,
+            maxSegmentsPerCell=maxNumSegments,
+            numLearningPoints=3,  # number repetitions for learning
+            seed=1
+        )
+
+        numFeatures = 3  # new: 3 # original: 3
+        numPoints = 5  # new: 5 # original: 10
+        numLocations = 5  # new: 5 # original: 10
+        numObjects = 5  # new: 2 # original: 10
+        numRptsPerSensation = 2
+
+        self.objectMachine = createObjectMachine(
+            machineType="simple",
+            numInputBits=20,
+            sensorInputSize=1024,
+            externalInputSize=1024,
+            numCorticalColumns=3,
+            seed=40,
+        )
+        self.objectMachine.createRandomObjects(numObjects, numPoints=numPoints,
+                                          numLocations=numLocations,
+                                          numFeatures=numFeatures)
+
+    def test_one_toy_l2(self):
+        # 4 sensations in a sequence fixed
+        objects = {
+            "simple": [
+                # location, feature for CC0
+                {0: (set([1, 2, 3]), set([1, 2, 3]))},
+                {0: (set([4, 5, 6]), set([4, 5, 6]))},
+                {0: (set([7, 8, 9]), set([7, 8, 9]))},
+                {0: (set([10, 11, 12]), set([10, 11, 12]))},
+            ]
+        }
+        # learn the sensations
+        print "train single column: 4-sequence"
+        self.exp1.learnObjects(objects)
+
+        sensationStepsSingleColumn = objects["simple"]
+
+        print "inference: single column"
+        self.exp1.sendReset()
+        l2ActiveCellsSingleColumn = []
+
+        simpleObjectRepresentation = self.exp1.objectL2Representations["simple"][0]
+        for sensation in sensationStepsSingleColumn:
+            self.exp1.infer([sensation], objectName="simple", reset=False)
+
+            active = self.exp1.getL2Representations()[0]
+            l2ActiveCellsSingleColumn.append(active)
+
+            print
+            print("SENSATION", sensation)
+            print("Target object", simpleObjectRepresentation)
+            print("L2 active", active)
+
+            self.assertTrue(len(simpleObjectRepresentation.difference(active)) == 0,
+                            'Not all object cells were activated missing %s' % simpleObjectRepresentation.difference(
+                                    active))
+
+        active = self.exp1.getL2Representations()[0]
+        self.assertTrue(np.array_equal(active, simpleObjectRepresentation),
+                        '%s additional active cells were made, did not converge' % (len(active) - len(simpleObjectRepresentation)))
+
+    def test_two_unique_toys_l2(self):
+        # 4 sensations in a sequence fixed
+        objects = {
+            "simple": [
+                # location, feature for CC0
+                {0: (set([1, 2, 3]), set([1, 2, 3]))},
+                {0: (set([4, 5, 6]), set([4, 5, 6]))},
+                {0: (set([7, 8, 9]), set([7, 8, 9]))},
+                {0: (set([10, 11, 12]), set([10, 11, 12]))},
+            ],
+            "simple2": [
+                # location, feature for CC0
+                {0: (set([13, 14, 15]), set([13, 14, 15]))},
+                {0: (set([16, 17, 18]), set([16, 17, 18]))},
+                {0: (set([19, 20, 21]), set([19, 20, 21]))},
+                {0: (set([22, 23, 24]), set([22, 23, 24]))},
+            ]
+        }
+        # learn the sensations
+        print "train single column: 4-sequence"
+        self.exp1.learnObjects(objects)
+        self.exp1.sendReset()
+
+        simpleObjectRepresentation = self.exp1.objectL2Representations["simple"][0]
+        simpleObjectRepresentation2 = self.exp1.objectL2Representations["simple2"][0]
+
+        for o in ["simple", "simple2"]:
+
+            sensationStepsSingleColumn = objects[o]
+            objectRepresentation = self.exp1.objectL2Representations[o][0]
+
+            print "inference test: single column - object %s" % o
+            print("Object %s representation" % o, objectRepresentation)
+
+            for i in range(len(sensationStepsSingleColumn)):
+                sensation = sensationStepsSingleColumn[i]
+                self.exp1.infer([sensation], objectName=o, reset=False)
+
+                active = self.exp1.getL2Representations()[0]
+                overlap = simpleObjectRepresentation.intersection(active)
+                overlap2 = simpleObjectRepresentation2.intersection(active)
+
+                print
+                print("Overlap %s %s/%s %s" % ("simple", len(overlap), len(simpleObjectRepresentation), overlap))
+                print("Overlap %s %s/%s %s" % ("simple2", len(overlap2), len(simpleObjectRepresentation2), overlap2))
+                print("L2 active", active)
+
+                self.assertTrue(len(objectRepresentation.difference(active)) == 0,
+                                'Not all object cells were activated missing %s' % objectRepresentation.difference(
+                                    active))
+
+                # Check if last sensation converged
+                if (i == len(sensationStepsSingleColumn) - 1):
+                    self.assertTrue(np.array_equal(active, objectRepresentation),
+                                    '%s additional active cells were made, did not converge' % (
+                                                len(active) - len(objectRepresentation)))
+
+            # reset after object to avoid temporal sequence
+            self.exp1.sendReset()
+
+
+    def test_two_toys_common_sensations_l2(self):
+        # 4 sensations in a sequence fixed
+        objects = {
+            "simple": [
+                # location, feature for CC0
+                {0: (set([1, 2, 3]), set([1, 2, 3]))},
+                {0: (set([4, 5, 6]), set([4, 5, 6]))},
+                {0: (set([7, 8, 9]), set([7, 8, 9]))},
+                {0: (set([10, 11, 12]), set([10, 11, 12]))},
+            ],
+            "simple2": [
+                # location, feature for CC0
+                {0: (set([1, 2, 3]), set([1, 2, 3]))}, # same sensation -> both should be predicted
+                {0: (set([16, 17, 18]), set([16, 17, 18]))},
+                {0: (set([19, 20, 21]), set([19, 20, 21]))},
+                {0: (set([22, 23, 24]), set([22, 23, 24]))},
+            ]
+        }
+        # learn the sensations
+        print "train single column: 4-sequence"
+        self.exp1.learnObjects(objects)
+        self.exp1.sendReset()
+
+        simpleObjectRepresentation = self.exp1.objectL2Representations["simple"][0]
+        simpleObjectRepresentation2 = self.exp1.objectL2Representations["simple2"][0]
+
+        for o in ["simple", "simple2"]:
+
+            sensationStepsSingleColumn = objects[o]
+            objectRepresentation = self.exp1.objectL2Representations[o][0]
+
+            print "inference test: single column - object %s" % o
+            print("Object %s representation" % o, objectRepresentation)
+
+            for i in range(len(sensationStepsSingleColumn)):
+                sensation = sensationStepsSingleColumn[i]
+                self.exp1.infer([sensation], objectName=o, reset=False)
+
+                active = self.exp1.getL2Representations()[0]
+                overlap = simpleObjectRepresentation.intersection(active)
+                overlap2 = simpleObjectRepresentation2.intersection(active)
+
+                print
+                print("Overlap %s %s/%s %s" % ("simple", len(overlap), len(simpleObjectRepresentation), overlap))
+                print("Overlap %s %s/%s %s" % ("simple2", len(overlap2), len(simpleObjectRepresentation2), overlap2))
+                print("L2 active", active)
+
+
+                self.assertTrue(len(objectRepresentation.difference(active)) == 0,
+                               'Not all object cells were activated missing %s' % objectRepresentation.difference(active))
+
+                # First sensation should predict both objects possible
+                if (i == 0):
+                    self.assertTrue(len(simpleObjectRepresentation.difference(active)) == 0,
+                                    'First (overlapping) sensation did not predict both objects')
+                    self.assertTrue(len(simpleObjectRepresentation2.difference(active)) == 0,
+                                    'First (overlapping) sensation did not predict both objects')
+
+                # Check if last sensation converged
+                if (i == len(sensationStepsSingleColumn)-1):
+                    self.assertTrue(np.array_equal(active, objectRepresentation),
+                                    '%s additional active cells were made, did not converge' % (len(active) - len(objectRepresentation)))
+
+            # reset after object to avoid temporal sequence
+            self.exp1.sendReset()
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/bayesian/test_baysian_tm_full.py
+++ b/tests/bayesian/test_baysian_tm_full.py
@@ -13,14 +13,14 @@ class BayesianTMTest(unittest.TestCase):
         maxNumSegments = 2
         L2Overrides = {
             "learningRate": 0.1,
-            "noise": 0.01,
+            "noise": 1e-6,
             "cellCount": 256,  # new: 256 # original: 4096
             "inputWidth": 8192,  # new: 8192 # original: 16384 (?)
         }
 
         L4Overrides = {
             "learningRate": 0.1,
-            "noise": 0.01,
+            "noise": 1e-6,
             "cellsPerColumn": 4,  # new: 4 # original 32
             "columnCount": 2048,  # new: 2048 # original: 2048
             "minThreshold": 0.35,

--- a/tests/bayesian/test_weight_explosion_averages.py
+++ b/tests/bayesian/test_weight_explosion_averages.py
@@ -1,0 +1,73 @@
+import unittest
+import numpy as np
+
+# Test all cases of co-activity/activity and ensure that the weights do not explode
+# Co-activity should never be higher than the Neuron-activities multiplied
+class WeightExplosionTest(unittest.TestCase):
+    def setUp(self):
+        self.numSegments = 1
+        self.cellCount = 1
+        self.inputSize = 1
+        self.learningRate = 0.1
+        self.noise = 0.00001
+
+    # test 4 cases:
+    # no input & no bias
+    # no input
+    # no bias
+    # input & bias (+ co-activity)
+
+    def test_no_input_and_bias_activity(self):
+        inputValues = np.array([0.0])
+        segments = np.array([[0.0]])
+
+        movingAverage = np.full((self.numSegments, self.cellCount, self.inputSize), self.noise**2) # 1.0 / (self.cellCount * self.inputSize))
+        movingAverageBias = np.full((self.numSegments, self.cellCount), self.noise) # 1.0 /self. cellCount)
+        movingAverageInput = np.full((self.inputSize), self.noise) # 1.0 / self.inputSize)
+
+        for i in range(1000):
+
+            # Updating moving average input activity
+            noisy_input_vector = (1 - self.noise) * inputValues
+            # Consider only active segments
+            noisy_input_vector += self.noise
+            movingAverageInput += self.learningRate * (
+                    noisy_input_vector - movingAverageInput
+            )
+
+            # First update input values (includes learning rate)
+            # Then use the probabilities of activity for movingAverage calculation
+            # Instead of using 1 -> would lead to weight explosion, because we calculate weights based on MovingAverageInput
+            inputProbabilities = inputValues
+            inputProbabilities[inputValues.nonzero()] = movingAverageInput[inputValues.nonzero()]
+
+            # Updating moving average weights to input
+            noisy_connection_matrix = np.outer((1 - self.noise ** 2) * segments, inputProbabilities)
+            # Consider only active segments
+            noisy_connection_matrix += self.noise ** 2
+            noisy_connection_matrix = noisy_connection_matrix.reshape(self.numSegments, self.cellCount, self.inputSize)
+            movingAverage += self.learningRate * (
+                    noisy_connection_matrix - movingAverage
+            )
+
+            # Updating moving average bias of each segment
+            noisy_activation_vector = (1 - self.noise) * segments
+            # Consider only active segments
+            noisy_activation_vector += self.noise
+            movingAverageBias += self.learningRate * (
+                    noisy_activation_vector - movingAverageBias
+            )
+
+        # AFTER TEST
+        weights = movingAverage / np.outer(
+            movingAverageBias,
+            movingAverageInput
+        ).reshape(movingAverage.shape)
+        # set division by zero to zero since this represents unused segments
+        weights[np.isnan(weights)] = 0
+
+        self.assertTrue(weights.max() < 1.1, "Weights exploded")
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Added tests for column pooler and weights (playground), fixed bayesian-tm: Need to set weights explicitly to 1 to avoid explosion.

Whats done:
1) Weights explicitly set to 1.0 to avoid explosion of weights&biases of unused units.
2) Added the input probabilities -> input values moving averages, to account for their activity properly. 
3) Removed initialization again, as it caused less high probabilities after normalization (could be added back)
4) Added a small initial test for the column pooler which verifies that the same representation is invoked for sensations for one object, two objects and objects that share sensations. Especially with shared sensations we have problems. (However, column pooler needs a rework without the forgetting)
5) Added a small test for weight explosion, that simply shows convergence to the noise without input. (when removing our > 0 condition mask). We can play around with this testcase.