### PR TITLE
If feedforward probabilities are used, use the maximum of timestep t …

### DIFF
--- a/htmresearch/algorithms/bayesian_column_pooler_base.py
+++ b/htmresearch/algorithms/bayesian_column_pooler_base.py
@@ -367,11 +367,13 @@ class BayesianColumnPoolerBase(object):
 
         # Forgetting process for values that doesn't get feed forward input
         self.activeCells -= self.forgetting*self.activeCells
+
         # Update cell values with new activation
-        # Activation is either 1 (for every feed forward input) or it is set to the activation itself
-        self.activeCells[
-            feedForwardActivation > 0.0
-            ] = feedForwardActivation[feedForwardActivation > 0.0] if self.useProximalProbabilities else 1
+        # Activation is either 1 (for every feed forward input) or it is set to the maximum from the new activation/discounted timestep t-1 activation
+        if self.useProximalProbabilities:
+            self.activeCells = np.maximum(self.activeCells, feedForwardActivation)
+        else:
+            self.activeCells[feedForwardActivation > 0.0] = 1
 
         activity = self.activeCells.copy()
 


### PR DESCRIPTION
…and timestep t-1*forgetting, to not unequally treat neurons which have any support (e.g. very low) vs. none support